### PR TITLE
Prevent unwanted overscroll bounce when `preferPosition` cannot be reached

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -34,6 +34,7 @@ class MyHomePage extends StatefulWidget {
 
 class _MyHomePageState extends State<MyHomePage> {
   static const maxCount = 100;
+  static const double maxHeight = 1000;
   final random = math.Random();
   final scrollDirection = Axis.vertical;
 
@@ -48,7 +49,7 @@ class _MyHomePageState extends State<MyHomePage> {
             Rect.fromLTRB(0, 0, 0, MediaQuery.of(context).padding.bottom),
         axis: scrollDirection);
     randomList = List.generate(maxCount,
-        (index) => <int>[index, (1000 * random.nextDouble()).toInt()]);
+            (index) => <int>[index, (maxHeight * random.nextDouble()).toInt()]);
   }
 
   @override
@@ -56,6 +57,22 @@ class _MyHomePageState extends State<MyHomePage> {
     return Scaffold(
       appBar: AppBar(
         title: Text(widget.title),
+        actions: [
+          IconButton(
+            onPressed: () {
+              setState(() => counter = 0);
+              _scrollToCounter();
+            },
+            icon: Text('First'),
+          ),
+          IconButton(
+            onPressed: () {
+              setState(() => counter = maxCount - 1);
+              _scrollToCounter();
+            },
+            icon: Text('Last'),
+          )
+        ],
       ),
       body: ListView(
         scrollDirection: scrollDirection,
@@ -68,7 +85,7 @@ class _MyHomePageState extends State<MyHomePage> {
         }).toList(),
       ),
       floatingActionButton: FloatingActionButton(
-        onPressed: _scrollToIndex,
+        onPressed: _nextCounter,
         tooltip: 'Increment',
         child: Text(counter.toString()),
       ),
@@ -76,15 +93,14 @@ class _MyHomePageState extends State<MyHomePage> {
   }
 
   int counter = -1;
-  Future _scrollToIndex() async {
-    setState(() {
-      counter++;
+  Future _nextCounter() {
+    setState(() => counter = (counter + 1) % maxCount);
+    return _scrollToCounter();
+  }
 
-      if (counter >= maxCount) counter = 0;
-    });
-
+  Future _scrollToCounter() async {
     await controller.scrollToIndex(counter,
-        preferPosition: AutoScrollPosition.begin);
+        preferPosition: AutoScrollPosition.middle);
     controller.highlight(counter);
   }
 

--- a/lib/scroll_to_index.dart
+++ b/lib/scroll_to_index.dart
@@ -413,12 +413,15 @@ mixin AutoScrollControllerMixin on ScrollController
       double targetOffset = _directionalOffsetToRevealInViewport(
           index, _positionToAlignment(preferPosition));
 
-      //content shorter than the whole scroll view
-      //this will prevent from scrolling bounce for a non-scrollable scroll view.
-      if (position.extentBefore == 0 && targetOffset < position.minScrollExtent)
-        targetOffset = position.minScrollExtent;
-      else if (position.extentAfter == 0 && targetOffset > position.maxScrollExtent)
-        targetOffset = position.maxScrollExtent;
+      // The content preferred position might be impossible to reach
+      // for items close to the edges of the scroll content, e.g.
+      // we cannot put the first item at the end of the viewport or
+      // the last item at the beginning. Trying to do so might lead
+      // to a bounce at either the top or bottom, unless the scroll
+      // physics are set to clamp. To prevent this, we limit the
+      // offset to not overshoot the extent in either direction.
+      targetOffset = targetOffset.clamp(
+          position.minScrollExtent, position.maxScrollExtent);
 
       await move(targetOffset);
     } else {


### PR DESCRIPTION
This fixes #73 (more details there) by clamping the target offset to the min / max scroll extent when a `preferPosition` is set, removing the original check that only went into effect when the current scroll was already at the min or max.

This also updates the example app with a First / Last buttons in the AppBar that scroll to the first / last index in the list.