### PR TITLE
Allow overriding animation curve

### DIFF
--- a/lib/scroll_to_index.dart
+++ b/lib/scroll_to_index.dart
@@ -73,7 +73,8 @@ abstract class AutoScrollController implements ScrollController {
   /// scroll to the giving index
   Future scrollToIndex(int index,
       {Duration duration: scrollAnimationDuration,
-      AutoScrollPosition? preferPosition});
+      AutoScrollPosition? preferPosition,
+      Curve curve});
 
   /// highlight the item
   Future highlight(int index,
@@ -203,16 +204,18 @@ mixin AutoScrollControllerMixin on ScrollController
   @override
   Future scrollToIndex(int index,
       {Duration duration: scrollAnimationDuration,
-      AutoScrollPosition? preferPosition}) async {
+      AutoScrollPosition? preferPosition,
+      Curve curve = Curves.ease}) async {
     return co(
         this,
         () => _scrollToIndex(index,
-            duration: duration, preferPosition: preferPosition));
+            duration: duration, preferPosition: preferPosition, curve: curve));
   }
 
   Future _scrollToIndex(int index,
       {Duration duration: scrollAnimationDuration,
-      AutoScrollPosition? preferPosition}) async {
+      AutoScrollPosition? preferPosition,
+      Curve curve = Curves.ease}) async {
     assert(duration > Duration.zero);
 
     // In listView init or reload case, widget state of list item may not be ready for query.
@@ -240,7 +243,7 @@ mixin AutoScrollControllerMixin on ScrollController
 
       await _bringIntoViewportIfNeed(index, preferPosition,
           (double offset) async {
-        await animateTo(offset, duration: duration, curve: Curves.ease);
+        await animateTo(offset, duration: duration, curve: curve);
         await _waitForWidgetStateBuild();
         return null;
       });
@@ -283,7 +286,7 @@ mixin AutoScrollControllerMixin on ScrollController
         spentDuration += suggestedDuration ?? moveDuration;
         final oldOffset = offset;
         await animateTo(currentOffset,
-            duration: suggestedDuration ?? moveDuration, curve: Curves.ease);
+            duration: suggestedDuration ?? moveDuration, curve: curve);
         await _waitForWidgetStateBuild();
         if (!hasClients || offset == oldOffset) {
           // already scroll to begin or end
@@ -302,7 +305,7 @@ mixin AutoScrollControllerMixin on ScrollController
             final remaining = duration - spentDuration;
             await animateTo(finalOffset,
                 duration: remaining <= Duration.zero ? _millisecond : remaining,
-                curve: Curves.ease);
+                curve: curve);
             await _waitForWidgetStateBuild();
 
             // not sure why it doesn't scroll to the given offset, try more within 3 times
@@ -312,7 +315,7 @@ mixin AutoScrollControllerMixin on ScrollController
                   i < count && hasClients && offset != finalOffset;
                   i++) {
                 await animateTo(finalOffset,
-                    duration: _millisecond, curve: Curves.ease);
+                    duration: _millisecond, curve: curve);
                 await _waitForWidgetStateBuild();
               }
             }
@@ -385,7 +388,7 @@ mixin AutoScrollControllerMixin on ScrollController
         else
           return true;
       } (), "Please try to wrap all first level children widgets with AutoScrollTag.");
-      
+
       absoluteOffsetToViewport = offsetToLastState?.offset;
       if (absoluteOffsetToViewport == null)
         absoluteOffsetToViewport = defaultScrollDistanceOffset;
@@ -652,7 +655,7 @@ class AutoScrollTagState<W extends AutoScrollTag> extends State<W>
   }
 }
 
-Widget buildHighlightTransition({required BuildContext context, required Animation<double> highlight, 
+Widget buildHighlightTransition({required BuildContext context, required Animation<double> highlight,
   required Widget child, Color? background, Color? highlightColor}) {
   return DecoratedBoxTransition(
     decoration: DecorationTween(


### PR DESCRIPTION
ScrollToIndex accepts optional parameter to use an animation curve other than Curves.ease (Curves.ease will be used by default if no Curve is specified)