### PR TITLE
Add clampToMaxScrollExtent parameter and fix lint warnings 

### DIFF
--- a/lib/scroll_to_index.dart
+++ b/lib/scroll_to_index.dart
@@ -27,11 +27,11 @@ Rect defaultViewportBoundaryGetter() => Rect.zero;
 
 abstract class AutoScrollController implements ScrollController {
   factory AutoScrollController(
-      {double initialScrollOffset: 0.0,
-      bool keepScrollOffset: true,
+      {double initialScrollOffset = 0.0,
+      bool keepScrollOffset = true,
       double? suggestedRowHeight,
-      bool clampToMaxScrollExtent: true,
-      ViewportBoundaryGetter viewportBoundaryGetter:
+      bool clampToMaxScrollExtent = true,
+      ViewportBoundaryGetter viewportBoundaryGetter =
           defaultViewportBoundaryGetter,
       Axis? axis,
       String? debugLabel,
@@ -58,6 +58,7 @@ abstract class AutoScrollController implements ScrollController {
   /// used to choose which direction you are using.
   /// e.g. axis == Axis.horizontal ? (r) => r.left : (r) => r.top
   AxisValueGetter get beginGetter;
+
   AxisValueGetter get endGetter;
 
   /// detect if it's in scrolling (scrolling is a async process)
@@ -74,14 +75,14 @@ abstract class AutoScrollController implements ScrollController {
 
   /// scroll to the giving index
   Future scrollToIndex(int index,
-      {Duration duration: scrollAnimationDuration,
+      {Duration duration = scrollAnimationDuration,
       AutoScrollPosition? preferPosition});
 
   /// highlight the item
   Future highlight(int index,
-      {bool cancelExistHighlights: true,
-      Duration highlightDuration: _highlightDuration,
-      bool animated: true});
+      {bool cancelExistHighlights = true,
+      Duration highlightDuration = _highlightDuration,
+      bool animated = true});
 
   /// cancel all highlight item immediately.
   void cancelAllHighlights();
@@ -105,11 +106,11 @@ class SimpleAutoScrollController extends ScrollController
   final AxisValueGetter endGetter;
 
   SimpleAutoScrollController(
-      {double initialScrollOffset: 0.0,
-      bool keepScrollOffset: true,
+      {double initialScrollOffset = 0.0,
+      bool keepScrollOffset = true,
       this.suggestedRowHeight,
       this.clampToMaxScrollExtent = true,
-      this.viewportBoundaryGetter: defaultViewportBoundaryGetter,
+      this.viewportBoundaryGetter = defaultViewportBoundaryGetter,
       required this.beginGetter,
       required this.endGetter,
       AutoScrollController? copyTagsFrom,
@@ -136,12 +137,12 @@ class PageAutoScrollController extends PageController
   final AxisValueGetter endGetter = (r) => r.right;
 
   PageAutoScrollController(
-      {int initialPage: 0,
-      bool keepPage: true,
-      double viewportFraction: 1.0,
+      {int initialPage = 0,
+      bool keepPage = true,
+      double viewportFraction = 1.0,
       this.suggestedRowHeight,
       this.clampToMaxScrollExtent = true,
-      this.viewportBoundaryGetter: defaultViewportBoundaryGetter,
+      this.viewportBoundaryGetter = defaultViewportBoundaryGetter,
       AutoScrollController? copyTagsFrom,
       String? debugLabel})
       : super(
@@ -153,17 +154,24 @@ class PageAutoScrollController extends PageController
 }
 
 enum AutoScrollPosition { begin, middle, end }
+
 mixin AutoScrollControllerMixin on ScrollController
     implements AutoScrollController {
   @override
   final Map<int, AutoScrollTagState> tagMap = <int, AutoScrollTagState>{};
+
   double? get suggestedRowHeight;
+
   bool get clampToMaxScrollExtent;
+
   ViewportBoundaryGetter get viewportBoundaryGetter;
+
   AxisValueGetter get beginGetter;
+
   AxisValueGetter get endGetter;
 
   bool __isAutoScrolling = false;
+
   set _isAutoScrolling(bool isAutoScrolling) {
     __isAutoScrolling = isAutoScrolling;
     if (!isAutoScrolling &&
@@ -175,6 +183,7 @@ mixin AutoScrollControllerMixin on ScrollController
   bool get isAutoScrolling => __isAutoScrolling;
 
   ScrollController? _parentController;
+
   @override
   set parentController(ScrollController parentController) {
     if (_parentController == parentController) return;
@@ -211,7 +220,7 @@ mixin AutoScrollControllerMixin on ScrollController
   static const maxBound = 30; // 0.5 second if 60fps
   @override
   Future scrollToIndex(int index,
-      {Duration duration: scrollAnimationDuration,
+      {Duration duration = scrollAnimationDuration,
       AutoScrollPosition? preferPosition}) async {
     return co(
         this,
@@ -220,7 +229,7 @@ mixin AutoScrollControllerMixin on ScrollController
   }
 
   Future _scrollToIndex(int index,
-      {Duration duration: scrollAnimationDuration,
+      {Duration duration = scrollAnimationDuration,
       AutoScrollPosition? preferPosition}) async {
     assert(duration > Duration.zero);
 
@@ -277,12 +286,11 @@ mixin AutoScrollControllerMixin on ScrollController
         prevOffset = currentOffset;
         final nearest = _getNearestIndex(index);
 
-        if (tagMap[nearest ?? 0] == null) 
-          return null;
+        if (tagMap[nearest ?? 0] == null) return null;
 
         final moveTarget =
             _forecastMoveUnit(index, nearest, usedSuggestedRowHeightIfAny)!;
-        
+
         // assume suggestRowHeight will move to correct offset in just one time.
         // if the rule doesn't work (in variable row height case), we will use backup solution (non-suggested way)
         final suggestedDuration =
@@ -339,9 +347,9 @@ mixin AutoScrollControllerMixin on ScrollController
 
   @override
   Future highlight(int index,
-      {bool cancelExistHighlights: true,
-      Duration highlightDuration: _highlightDuration,
-      bool animated: true}) async {
+      {bool cancelExistHighlights = true,
+      Duration highlightDuration = _highlightDuration,
+      bool animated = true}) async {
     final tag = tagMap[index];
     return tag == null
         ? null
@@ -388,7 +396,7 @@ mixin AutoScrollControllerMixin on ScrollController
     } else {
       final offsetToLastState =
           _offsetToRevealInViewport(currentNearestIndex, alignment);
-      
+
       absoluteOffsetToViewport = offsetToLastState?.offset;
       if (absoluteOffsetToViewport == null)
         absoluteOffsetToViewport = defaultScrollDistanceOffset;
@@ -411,7 +419,6 @@ mixin AutoScrollControllerMixin on ScrollController
   /// bring the state node (already created but all of it may not be fully in the viewport) into viewport
   Future _bringIntoViewportIfNeed(int index, AutoScrollPosition? preferPosition,
       Future move(double offset)) async {
-
     if (preferPosition != null) {
       double targetOffset = _directionalOffsetToRevealInViewport(
           index, _positionToAlignment(preferPosition));
@@ -487,9 +494,8 @@ mixin AutoScrollControllerMixin on ScrollController
     if (ctx == null) return null;
 
     final renderBox = ctx.findRenderObject()!;
-    assert(Scrollable.of(ctx) != null);
     final RenderAbstractViewport viewport =
-        RenderAbstractViewport.of(renderBox)!;
+        RenderAbstractViewport.of(renderBox);
     final revealedOffset = viewport.getOffsetToReveal(renderBox, alignment);
 
     return revealedOffset;
@@ -503,7 +509,9 @@ void _cancelAllHighlights([AutoScrollTagState? state]) {
   _highlights.clear();
 }
 
-typedef Widget TagHighlightBuilder(BuildContext context, Animation<double> highlight);
+typedef Widget TagHighlightBuilder(
+    BuildContext context, Animation<double> highlight);
+
 class AutoScrollTag extends StatefulWidget {
   final AutoScrollController controller;
   final int index;
@@ -521,8 +529,9 @@ class AutoScrollTag extends StatefulWidget {
       this.builder,
       this.color,
       this.highlightColor,
-      this.disabled: false})
-      : assert(child != null || builder != null), super(key: key);
+      this.disabled = false})
+      : assert(child != null || builder != null),
+        super(key: key);
 
   @override
   AutoScrollTagState createState() {
@@ -588,9 +597,13 @@ class AutoScrollTagState<W extends AutoScrollTag> extends State<W>
   @override
   Widget build(BuildContext context) {
     final animation = _controller ?? kAlwaysDismissedAnimation;
-    return widget.builder?.call(context, animation)
-          ?? buildHighlightTransition(context: context, highlight: animation, child: widget.child!,
-            background: widget.color, highlightColor: widget.highlightColor);
+    return widget.builder?.call(context, animation) ??
+        buildHighlightTransition(
+            context: context,
+            highlight: animation,
+            child: widget.child!,
+            background: widget.color,
+            highlightColor: widget.highlightColor);
   }
 
   //used to make sure we will drop the old highlight
@@ -599,9 +612,9 @@ class AutoScrollTagState<W extends AutoScrollTag> extends State<W>
 
   /// this function can be called multiple times. every call will reset the highlight style.
   Future highlight(
-      {bool cancelExisting: true,
-      Duration highlightDuration: _highlightDuration,
-      bool animated: true}) async {
+      {bool cancelExisting = true,
+      Duration highlightDuration = _highlightDuration,
+      bool animated = true}) async {
     if (!mounted) return null;
 
     if (cancelExisting) {
@@ -647,7 +660,7 @@ class AutoScrollTagState<W extends AutoScrollTag> extends State<W>
     return null;
   }
 
-  void _cancelController({bool reset: true}) {
+  void _cancelController({bool reset = true}) {
     if (_controller != null) {
       if (_controller!.isAnimating) _controller!.stop();
 
@@ -656,17 +669,20 @@ class AutoScrollTagState<W extends AutoScrollTag> extends State<W>
   }
 }
 
-Widget buildHighlightTransition({required BuildContext context, required Animation<double> highlight, 
-  required Widget child, Color? background, Color? highlightColor}) {
+Widget buildHighlightTransition(
+    {required BuildContext context,
+    required Animation<double> highlight,
+    required Widget child,
+    Color? background,
+    Color? highlightColor}) {
   return DecoratedBoxTransition(
-    decoration: DecorationTween(
-      begin: background != null ?
-      BoxDecoration(color: background) :
-      BoxDecoration(),
-      end: background != null ?
-      BoxDecoration(color: background) :
-      BoxDecoration(color: highlightColor)
-    ).animate(highlight),
-    child: child
-  );
+      decoration: DecorationTween(
+              begin: background != null
+                  ? BoxDecoration(color: background)
+                  : BoxDecoration(),
+              end: background != null
+                  ? BoxDecoration(color: background)
+                  : BoxDecoration(color: highlightColor))
+          .animate(highlight),
+      child: child);
 }

--- a/lib/scroll_to_index.dart
+++ b/lib/scroll_to_index.dart
@@ -30,6 +30,7 @@ abstract class AutoScrollController implements ScrollController {
       {double initialScrollOffset: 0.0,
       bool keepScrollOffset: true,
       double? suggestedRowHeight,
+      bool clampToMaxScrollExtent: true,
       ViewportBoundaryGetter viewportBoundaryGetter:
           defaultViewportBoundaryGetter,
       Axis? axis,
@@ -39,6 +40,7 @@ abstract class AutoScrollController implements ScrollController {
         initialScrollOffset: initialScrollOffset,
         keepScrollOffset: keepScrollOffset,
         suggestedRowHeight: suggestedRowHeight,
+        clampToMaxScrollExtent: clampToMaxScrollExtent,
         viewportBoundaryGetter: viewportBoundaryGetter,
         beginGetter: axis == Axis.horizontal ? (r) => r.left : (r) => r.top,
         endGetter: axis == Axis.horizontal ? (r) => r.right : (r) => r.bottom,
@@ -94,6 +96,8 @@ class SimpleAutoScrollController extends ScrollController
   @override
   final double? suggestedRowHeight;
   @override
+  final bool clampToMaxScrollExtent;
+  @override
   final ViewportBoundaryGetter viewportBoundaryGetter;
   @override
   final AxisValueGetter beginGetter;
@@ -104,6 +108,7 @@ class SimpleAutoScrollController extends ScrollController
       {double initialScrollOffset: 0.0,
       bool keepScrollOffset: true,
       this.suggestedRowHeight,
+      this.clampToMaxScrollExtent = true,
       this.viewportBoundaryGetter: defaultViewportBoundaryGetter,
       required this.beginGetter,
       required this.endGetter,
@@ -122,6 +127,8 @@ class PageAutoScrollController extends PageController
   @override
   final double? suggestedRowHeight;
   @override
+  final bool clampToMaxScrollExtent;
+  @override
   final ViewportBoundaryGetter viewportBoundaryGetter;
   @override
   final AxisValueGetter beginGetter = (r) => r.left;
@@ -133,6 +140,7 @@ class PageAutoScrollController extends PageController
       bool keepPage: true,
       double viewportFraction: 1.0,
       this.suggestedRowHeight,
+      this.clampToMaxScrollExtent = true,
       this.viewportBoundaryGetter: defaultViewportBoundaryGetter,
       AutoScrollController? copyTagsFrom,
       String? debugLabel})
@@ -150,6 +158,7 @@ mixin AutoScrollControllerMixin on ScrollController
   @override
   final Map<int, AutoScrollTagState> tagMap = <int, AutoScrollTagState>{};
   double? get suggestedRowHeight;
+  bool get clampToMaxScrollExtent;
   ViewportBoundaryGetter get viewportBoundaryGetter;
   AxisValueGetter get beginGetter;
   AxisValueGetter get endGetter;
@@ -415,8 +424,9 @@ mixin AutoScrollControllerMixin on ScrollController
       // physics are set to clamp. To prevent this, we limit the
       // offset to not overshoot the extent in either direction.
       targetOffset = targetOffset.clamp(
-          position.minScrollExtent, position.maxScrollExtent);
-
+        position.minScrollExtent,
+        clampToMaxScrollExtent ? position.maxScrollExtent : double.maxFinite,
+      );
       await move(targetOffset);
     } else {
       final begin = _directionalOffsetToRevealInViewport(index, 0);


### PR DESCRIPTION
- In my use case, when the height of the list view is dynamic, the scrolling to the index position may not be correct (the offset is clamped due to the list view's dynamic maxScrollExtent being wrong). Since we added support for the list view to fill the viewport, I added the `clampToMaxScrollExtent` parameter to avoid the offset being clamped.
- Fix lint warnings.